### PR TITLE
兼容 Android 图片分享大小限制

### DIFF
--- a/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxShareHandler.kt
+++ b/android/src/main/kotlin/com/jarvan/fluwx/handlers/FluwxShareHandler.kt
@@ -105,7 +105,11 @@ internal interface FluwxShareHandler : CoroutineScope {
             val uint8List = map["uint8List"] as? ByteArray
             val imageObject = uint8List?.let {
                 WXImageObject().apply {
-                    imageData = it
+                    if (supportFileProvider && targetHigherThanN) {
+                        setImagePath(getFileContentUri(it.toCacheFile(context, ".png")))
+                    } else {
+                        imagePath = it.toExternalCacheFile(context, ".png")?.absolutePath
+                    }
                     imgDataHash = imgHash
                 }
             }?:run {


### PR DESCRIPTION
二、图片类型分享示例

WXImageObject （WXMediaMessage.IMediaObject 的派生类，用于描述一个图片对象）

根据微信官方文档
imageData 图片的二进制数据	内容大小不超过 1MB
imagePath 图片的本地路径 对应图片内容大小不超过 25MB